### PR TITLE
Follow the latest quipper ruby style guide

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,6 +1,5 @@
 Style/StringLiterals:
-  EnforcedStyle: double_quotes
-  Enabled: true
+  Enabled: false
 
 Layout/DotPosition:
   EnforcedStyle: leading


### PR DESCRIPTION
Quipper devs had a discussion to revisit this topic. The short summary of that was basically we had disallowed having both string literals to avoid bikeshed for pull request reviews, but we agreed that we are smart enough not to fall into that pitfall, and we can follow what a part of code should be to express your intention, believing in your intelligence.

* The discussion was at https://github.com/quipper/quipper-ruby-style-guide/pull/6 (private repo)