### PR TITLE
Disable Style/EmptyCaseCondition:

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -21,3 +21,6 @@ Style/NumericPredicate:
 
 Naming/PredicateName:
   Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false

--- a/lib/quipper/rubocop/config/version.rb
+++ b/lib/quipper/rubocop/config/version.rb
@@ -3,7 +3,7 @@
 module Quipper
   module Rubocop
     module Config
-      VERSION = "0.1.1"
+      VERSION = "0.1.2"
     end
   end
 end


### PR DESCRIPTION
The pattern is used a good example even in ruby-style-guide, and we didn't discuss yet in https://github.com/quipper/quipper-ruby-style-guide. So the default config should be false

@quipper/web-devs Please review and merge~