### PR TITLE
Change Layout/DotPosition to trailing

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -2,8 +2,7 @@ Style/StringLiterals:
   Enabled: false
 
 Layout/DotPosition:
-  EnforcedStyle: leading
-  Enabled: true
+  EnforcedStyle: trailing
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space


### PR DESCRIPTION
## Refs:
(Sorry for in JP..)
https://github.com/onk/onkcop/blob/ca49e52a5ce740f39d589282d1d1bae33db54adf/config/rubocop.yml#L18-L22

^ It says,

- Line breaks in the method chain will end with.
- To prevent error when pasting on REPL
- It is convenient to comment between the code

## Slack

https://quipper.slack.com/archives/C04PAB42B/p1542880835849800